### PR TITLE
Hashtable check - Fix for DSC composite resources

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- Fix issue with DSC composite resources.
 - Fix issues with LF by hashtable check.
 
 ### Added

--- a/Source/Public/Measure-Hashtable.ps1
+++ b/Source/Public/Measure-Hashtable.ps1
@@ -43,7 +43,7 @@ function Measure-Hashtable
             $hashtableLines = $hashtable.Extent.Text -split '\n'
 
             # Hashtable should start with '@{' and end with '}'
-            if (($hashtableLines[0] -notmatch '@{\r' -and $hashtableLines[0] -notmatch '@{') -or
+            if (($hashtableLines[0] -notmatch '\s*@?{\r' -and $hashtableLines[0] -notmatch '\s*@?{$') -or
                 $hashtableLines[-1] -notmatch '\s*}')
             {
                 $script:diagnosticRecord['Extent'] = $hashtable.Extent

--- a/tests/Unit/Public/Measure-Hashtable.Tests.ps1
+++ b/tests/Unit/Public/Measure-Hashtable.Tests.ps1
@@ -357,7 +357,7 @@ Describe 'Measure-Hashtable' {
         }
 
         Context 'When composite resource is correctly formatted' {
-            It "Correctly formatted non-nested hashtable" {
+            It "Correctly formatted non-nested hashtable" -Skip:(!([bool]$IsWindows)) {
                 $invokeScriptAnalyzerParameters['ScriptDefinition'] = '
                         configuration test {
                             Script test

--- a/tests/Unit/Public/Measure-Hashtable.Tests.ps1
+++ b/tests/Unit/Public/Measure-Hashtable.Tests.ps1
@@ -79,7 +79,7 @@ Describe 'Measure-Hashtable' {
         }
 
         Context 'When composite resource is not correctly formatted' {
-            It 'Composite resource defined on a single line' {
+            It 'Composite resource defined on a single line' -Skip:(!([bool]$IsWindows)) {
                 $definition = '
                         configuration test {
                             Script test
@@ -95,7 +95,7 @@ Describe 'Measure-Hashtable' {
                 $record.RuleName | Should -Be $ruleName
             }
 
-            It 'Composite resource partially correct formatted' {
+            It 'Composite resource partially correct formatted' -Skip:(!([bool]$IsWindows)) {
                 $definition = '
                         configuration test {
                             Script test
@@ -113,7 +113,7 @@ Describe 'Measure-Hashtable' {
                 $record.RuleName | Should -Be $ruleName
             }
 
-            It 'Composite resource indentation not correct' {
+            It 'Composite resource indentation not correct' -Skip:(!([bool]$IsWindows)) {
                 $definition = '
                         configuration test {
                             Script test
@@ -179,7 +179,7 @@ Describe 'Measure-Hashtable' {
         }
 
         Context 'When composite resource is correctly formatted' {
-            It "Correctly formatted non-nested hashtable" {
+            It "Correctly formatted non-nested hashtable" -Skip:(!([bool]$IsWindows)) {
                 $definition = '
                         configuration test {
                             Script test
@@ -262,7 +262,7 @@ Describe 'Measure-Hashtable' {
         }
 
         Context 'When composite resource is not correctly formatted' {
-            It 'Composite resource defined on a single line' {
+            It 'Composite resource defined on a single line' -Skip:(!([bool]$IsWindows)) {
                 $invokeScriptAnalyzerParameters['ScriptDefinition'] = '
                         configuration test {
                             Script test
@@ -278,7 +278,7 @@ Describe 'Measure-Hashtable' {
 
             }
 
-            It 'Composite resource partially correct formatted' {
+            It 'Composite resource partially correct formatted' -Skip:(!([bool]$IsWindows)) {
                 $invokeScriptAnalyzerParameters['ScriptDefinition'] = '
                         configuration test {
                             Script test
@@ -295,7 +295,7 @@ Describe 'Measure-Hashtable' {
                 $record.RuleName | Should -Be $ruleName
             }
 
-            It 'Composite resource indentation not correct' {
+            It 'Composite resource indentation not correct' -Skip:(!([bool]$IsWindows)) {
                 $invokeScriptAnalyzerParameters['ScriptDefinition'] = '
                         configuration test {
                             Script test


### PR DESCRIPTION
#### Pull Request (PR) description
As mentioned in this [PR](https://github.com/PowerShell/xPSDesiredStateConfiguration/pull/617), the DSC composite resources are also being parsed as hashtables. I have wrote a fix, that should remove the false/positives on those resources. 
I have tested it against few DSC Resources - I have not observed any false positives. 

#### This Pull Request (PR) fixes the following issues
[PR](https://github.com/PowerShell/xPSDesiredStateConfiguration/pull/617)

#### Task list
- [x] Added an entry under the Unreleased section of the change log in the CHANGELOG.md.
      Entry should say what was changed, and how that affects users (if applicable).
- [ ] Documentation added/updated in README.md.
- [ ] Comment-based help added/updated for all new/changed functions.
- [ ] Localization strings added/updated in all localization files as appropriate.
- [ ] Unit tests added/updated.
- [x] New/changed code adheres to [DSC Resource Style Guidelines](https://github.com/PowerShell/DscResources/blob/master/StyleGuidelines.md) and [Best Practices](https://github.com/PowerShell/DscResources/blob/master/BestPractices.md).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dsccommunity/dscresource.analyzerrules/7)
<!-- Reviewable:end -->
